### PR TITLE
Fix flake8 config F401

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,5 @@
 max-line-length = 120
 extend-ignore =
     E203
-    F401 */**/__init__.py
+per-file-ignores =
+    __init__.py:F401


### PR DESCRIPTION
Fixes .flake8 configuration file, which is causing issues with flake8>=6.0.0 (see [release notes](https://flake8.pycqa.org/en/latest/release-notes/6.0.0.html#backwards-incompatible-changes) for reference)
Tested backwards compatibility with flake8==5.0.4