### PR TITLE
Replace `DataFrame.iteritems()` with `.items()`

### DIFF
--- a/codc/reader.py
+++ b/codc/reader.py
@@ -54,7 +54,7 @@ def _read_odb_generator(source, columns=None, aggregated=True, max_aggregated=-1
 
 def _read_odb_oneshot(source, columns=None):
     reduced = pandas.concat(_read_odb_generator(source, columns), sort=False, ignore_index=True)
-    for name, data in reduced.iteritems():
+    for name, data in reduced.items():
         if data.dtype == "object":
             data.where(pandas.notnull(data), None, inplace=True)
     return reduced

--- a/pyodc/encoder.py
+++ b/pyodc/encoder.py
@@ -80,7 +80,7 @@ def encode_single_dataframe(
 
     stream_class = BigEndianStream if bigendian else LittleEndianStream
 
-    codecs = [select_codec(name, data, (types or {}).get(name, None)) for name, data in dataframe.iteritems()]
+    codecs = [select_codec(name, data, (types or {}).get(name, None)) for name, data in dataframe.items()]
 
     # If a column order has been specified, sort the codecs according to it. otherwise sort
     # the codecs for the most efficient use of the given data

--- a/pyodc/reader.py
+++ b/pyodc/reader.py
@@ -58,7 +58,7 @@ def _read_odb_generator(source, columns=None, aggregated=True):
 
 def _read_odb_oneshot(source, columns=None):
     reduced = pandas.concat(_read_odb_generator(source, columns), sort=False, ignore_index=True)
-    for name, data in reduced.iteritems():
+    for name, data in reduced.items():
         if data.dtype == "object":
             data.where(pandas.notnull(data), None, inplace=True)
     return reduced


### PR DESCRIPTION
`DataFrame.iteritems()` was dropped in pandas 2.0.0 ([release notes](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes)). Replacing it with `obj.items()` as suggested by the release notes.
