### PR TITLE
Use findlibs to find odc library for codc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 *egg-info*
 .eggs
 .ipynb_checkpoints
+
+# editors
+.vscode

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The package contains two different implementations of the same library:
 * [pandoc]
 * [Jupyter Notebook]
 
-For `codc` to work, `odc` library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in `odc_DIR` environment variable, or the library directory can be included in `LD_LIBRARY_PATH`.
+For `codc` to work, `odc` library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in the `odc_DIR` or `ODC_DIR` environment variables, or the library directory can be included in `LD_LIBRARY_PATH`.
 
 ## Installation
 

--- a/codc/lib.py
+++ b/codc/lib.py
@@ -16,6 +16,7 @@
 import os
 
 import cffi
+import findlibs
 from pkg_resources import parse_version
 
 __odc_version__ = "1.4.0"
@@ -44,24 +45,11 @@ class PatchedLib:
     def __init__(self):
         ffi.cdef(self.__read_header())
 
-        libnames = [
-            "odccore",
-        ]
-        for env_var in ("ODC_DIR", "odc_DIR"):
-            if os.environ.get(env_var):
-                libnames.insert(0, os.path.join(os.environ[env_var], "lib/libodccore"))
-                libnames.insert(0, os.path.join(os.environ[env_var], "lib64/libodccore"))
-                libnames.insert(0, os.path.join(os.environ[env_var], "lib/libodccore.so"))
-                libnames.insert(0, os.path.join(os.environ[env_var], "lib64/libodccore.so"))
+        library_path = findlibs.find("odccore", pkg_name="odc")
+        if library_path is None:
+            raise RuntimeError("Cannot find the odccore library")
 
-        for libname in libnames:
-            try:
-                self.__lib = ffi.dlopen(libname)
-                break
-            except Exception as e:
-                last_exception = e
-        else:
-            raise CFFIModuleLoadFailed() from last_exception
+        self.__lib = ffi.dlopen(library_path)
 
         # Todo: Version check against __version__
 

--- a/codc/reader.py
+++ b/codc/reader.py
@@ -54,7 +54,7 @@ def _read_odb_generator(source, columns=None, aggregated=True, max_aggregated=-1
 
 def _read_odb_oneshot(source, columns=None):
     reduced = pandas.concat(_read_odb_generator(source, columns), sort=False, ignore_index=True)
-    for name, data in reduced.iteritems():
+    for name, data in reduced.items():
         if data.dtype == "object":
             data.where(pandas.notnull(data), None, inplace=True)
     return reduced

--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -25,7 +25,7 @@ Optional
 
 .. note::
 
-   For **codc** to work, the **odc** library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in ``odc_DIR`` environment variable, or the library directory can be included in ``LD_LIBRARY_PATH``.
+   For **codc** to work, the **odc** library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in the ``odc_DIR`` or ``ODC_DIR`` environment variables, or the library directory can be included in ``LD_LIBRARY_PATH``.
 
 
 .. _`odc`: https://github.com/ecmwf/odc

--- a/pyodc/encoder.py
+++ b/pyodc/encoder.py
@@ -80,7 +80,7 @@ def encode_single_dataframe(
 
     stream_class = BigEndianStream if bigendian else LittleEndianStream
 
-    codecs = [select_codec(name, data, (types or {}).get(name, None)) for name, data in dataframe.iteritems()]
+    codecs = [select_codec(name, data, (types or {}).get(name, None)) for name, data in dataframe.items()]
 
     # If a column order has been specified, sort the codecs according to it. otherwise sort
     # the codecs for the most efficient use of the given data

--- a/pyodc/reader.py
+++ b/pyodc/reader.py
@@ -58,7 +58,7 @@ def _read_odb_generator(source, columns=None, aggregated=True):
 
 def _read_odb_oneshot(source, columns=None):
     reduced = pandas.concat(_read_odb_generator(source, columns), sort=False, ignore_index=True)
-    for name, data in reduced.iteritems():
+    for name, data in reduced.items():
         if data.dtype == "object":
             data.where(pandas.notnull(data), None, inplace=True)
     return reduced

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         "cffi",
+        "findlibs>=0.0.5",
         "pandas",
     ],
     extras_require={},


### PR DESCRIPTION
This change is about using [findlibs](https://github.com/ecmwf/findlibs) to locate the odccore library when loading codc. Notes:

- findlibs (>= 0.0.5) is now an installation dependency
- there are some paths checked in the original code that are not checked by **findlibs**. This includes the paths without a library extension e.g. "${odc_DIR}/lib/libodccore". findlibs always uses a platform dependent extension and e.g. on Linux  it checks "${odc_DIR}/lib/libodccore.so". I wonder if it is acceptable in pyodc or findlibs needs to be enabled to check for library paths without an extension.
