### PR TITLE
Give explicit example for how to specify odc library location

### DIFF
--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -25,7 +25,7 @@ Optional
 
 .. note::
 
-   For **codc** to work, the **odc** library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in the ``odc_DIR`` or ``ODC_DIR`` environment variables, or the library directory can be included in ``LD_LIBRARY_PATH``. For example, if you cloned the odc source code to `$HOME/odc` and used `$HOME/odc/build` as the builddir, you could use `export odc_DIR=$HOME/git/odc/build`.
+   For **codc** to work, the **odc** library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in the ``odc_DIR`` or ``ODC_DIR`` environment variables, or the library directory can be included in ``LD_LIBRARY_PATH``. For example, if you cloned the odc source code to `$HOME/odc` and used `$HOME/odc/build` as the builddir, you could use `export odc_DIR=$HOME/odc/build`.
 
 
 .. _`odc`: https://github.com/ecmwf/odc

--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -25,7 +25,7 @@ Optional
 
 .. note::
 
-   For **codc** to work, the **odc** library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in the ``odc_DIR`` or ``ODC_DIR`` environment variables, or the library directory can be included in ``LD_LIBRARY_PATH``.
+   For **codc** to work, the **odc** library must be compiled and installed on the system and made available to Python (through the CFFI mechanism) as a shared library. There are multiple ways to make the library visible to CFFI: it can be installed as a system library, the installation prefix can be passed in the ``odc_DIR`` or ``ODC_DIR`` environment variables, or the library directory can be included in ``LD_LIBRARY_PATH``. For example, if you cloned the odc source code to `$HOME/odc` and used `$HOME/odc/build` as the builddir, you could use `export odc_DIR=$HOME/git/odc/build`.
 
 
 .. _`odc`: https://github.com/ecmwf/odc


### PR DESCRIPTION
It looks a while to understand how `ecmwf/findlibs` works, so I thought an explicit example might be nice here.