### PR TITLE
Feature/support pandas strings

### DIFF
--- a/codc/encoder.py
+++ b/codc/encoder.py
@@ -57,7 +57,7 @@ def encode_odb(
                     dtype = INTEGER
                 else:
                     dtype = DOUBLE
-            elif arr.dtype == "object":
+            if arr.dtype == "object" or pandas.api.types.is_string_dtype(arr):
                 if not arr.isnull().all() and all(s is None or isinstance(s, str) for s in arr):
                     dtype = STRING
                 elif arr.isnull().all():
@@ -65,7 +65,7 @@ def encode_odb(
 
         # With an inferred, or supplied column type, massage the data into a form that can be encoded
 
-        if arr.dtype == "object":
+        if arr.dtype == "object" or pandas.api.types.is_string_dtype(arr):
             # Map strings into an array that can be read in C
             if dtype == STRING:
                 return_arr = return_arr.astype("|S{}".format(max(8, 8 * (1 + ((max(len(s) for s in arr) - 1) // 8)))))
@@ -106,7 +106,7 @@ def encode_odb(
         data, dtype = infer_column_type(data, types.get(name, None))
         data_cache.append(data)
 
-        lib.odc_encoder_add_column(encoder, name.encode("utf-8"), dtype)
+        lib.odc_encoder_add_column(encoder, str(name).encode("utf-8"), dtype)
         lib.odc_encoder_column_set_data_array(
             encoder,
             i,

--- a/pyodc/codec.py
+++ b/pyodc/codec.py
@@ -432,7 +432,7 @@ def select_codec(column_name: str, data: pd.Series, data_type, bitfields):
                 data_type = DataType.DOUBLE
         elif data.dtype == "float32":
             data_type = DataType.REAL
-        elif data.dtype == "object":
+        elif data.dtype == "object" or pd.api.types.is_string_dtype(data):
             if not data.isnull().all() and all(s is None or isinstance(s, str) for s in data):
                 data_type = DataType.STRING
 

--- a/pyodc/codec.py
+++ b/pyodc/codec.py
@@ -481,7 +481,7 @@ def select_codec(column_name: str, data: pd.Series, data_type, bitfields):
             codec_class = ShortReal2
 
     elif data_type == DataType.STRING:
-        if data.nunique() == 1 and not data.hasnans:
+        if data.nunique() == 1 and len(data.iloc[0]) <= 8 and not data.hasnans:
             codec_class = ConstantString
         elif data.nunique() <= 256:
             codec_class = Int8String

--- a/pyodc/codec.py
+++ b/pyodc/codec.py
@@ -57,7 +57,7 @@ class Codec:
         return 8
 
     def encode_header(self, stream):
-        stream.encodeString(self.column_name)
+        stream.encodeString(str(self.column_name))
         stream.encodeInt32(self.type)
 
         if self.type == DataType.BITFIELD:

--- a/pyodc/stream.py
+++ b/pyodc/stream.py
@@ -45,7 +45,7 @@ class Stream:
         self.write(value.to_bytes(8, byteorder=self.byteOrder, signed=True))
 
     def encodeString(self, value: str):
-        self.encodeByteString(value.encode("utf-8"))
+        self.encodeByteString(str(value).encode("utf-8"))
 
     def encodeByteString(self, value: bytes):
         self.encodeInt32(len(value))

--- a/pyodc/stream.py
+++ b/pyodc/stream.py
@@ -45,7 +45,7 @@ class Stream:
         self.write(value.to_bytes(8, byteorder=self.byteOrder, signed=True))
 
     def encodeString(self, value: str):
-        self.encodeByteString(str(value).encode("utf-8"))
+        self.encodeByteString(value.encode("utf-8"))
 
     def encodeByteString(self, value: bytes):
         self.encodeInt32(len(value))

--- a/tests/test_pyodc_codc_interop.py
+++ b/tests/test_pyodc_codc_interop.py
@@ -1,0 +1,72 @@
+from tempfile import NamedTemporaryFile
+
+import numpy.testing
+import pandas
+import pytest
+from conftest import ODC_VERSION, codc, odc_modules
+
+import pyodc
+from pyodc import codec, Reader
+from pyodc.constants import INTERNAL_REAL_MISSING
+
+import pandas as pd
+import numpy as np
+
+# Each case is a single column and the expected codec 
+testcases = [
+    # Anything constant that fits in less than 8 bytes goes into codec.Constant
+    [[0, 0, 0, 0, 0, 0, 0], codec.Constant],
+    [[73] * 7, codec.Constant],
+    [[1.432] * 7, codec.Constant],
+
+    # Like the above but with missing values
+    [[1, 1, 1, None, 1, 1, 1], codec.ConstantOrMissing],
+    [[.1, .1, .1, None, .1, .1, .1], codec.RealConstantOrMissing],
+    
+    # Constant columns of strings of less than 8 bytes go into ConstantString
+    [["abcd"] * 7, codec.ConstantString],
+
+    # Constant columns of strings of more than 8 bytes currently get promoted to 
+    #  codec.Int8String but working on a version of ConstantString that supports longer strings.
+    [["abcdefghi"] * 7, codec.Int8String],
+
+    # Columns of strings with less than 2^n unique values go into Int8String or Int16String
+    [["aoeu", "aoeu", "aaaaaaaooooooo", "None", "boo", "squiggle", "a"], codec.Int8String],
+    [["longconstant"] + [str(num) for num in range(256)], codec.Int16String],
+
+    # Integers
+    [[1, 2, 3, 4, 5, 6, 7], codec.Int8],
+    [[1, None, 3, 4, 5, None, 7], codec.Int8Missing],
+    [[-512, None, 3, 7623, -22000, None, 7], codec.Int16Missing],
+
+    # Breaking the pattern, codec.Int32 accepts missing values.
+    [[-1234567, 8765432, None, 22, 22222222, -81222323, None], codec.Int32],
+
+    # Reals
+    [[999.99, 888.88, 777.77, 666.66, 555.55, 444.44, 333.33], codec.LongReal],
+    # [np.float32([999.99, 888.88, 777.77, 666.66, 555.55, 444.44, 333.33]), codec.ShortReal2],
+    # [np.float32([INTERNAL_REAL_MISSING[1], 888.88, 777.77, 666.66, 555.55, 444.44, 333.33]), codec.ShortReal],
+    
+]
+
+def first_codec(file):
+    return Reader(file).frames[0]._column_codecs[0]
+
+
+@pytest.mark.parametrize("encoder", odc_modules)
+@pytest.mark.parametrize("decoder", odc_modules)
+@pytest.mark.parametrize("testcase", testcases)
+def test_codec_choice(testcase, encoder, decoder):
+    "Check that codc and pyodc choose the same codec for all the test data"
+    testdata, expected_codec = testcase
+    df = pd.DataFrame(dict(column = testdata))
+
+    with NamedTemporaryFile() as fencode:
+        encoder.encode_odb(df, fencode.name)
+        round_tripped_data = decoder.read_odb(fencode.name, single = True)
+        codec = first_codec(fencode.name)
+
+    assert type(codec) == expected_codec
+
+    # Check the data round tripped
+    numpy.testing.assert_array_equal(df.column.values, round_tripped_data.column.values)


### PR DESCRIPTION
This PR adds support in pyodc for the new [pandas string dtype](https://pandas.pydata.org/pandas-docs/version/2.0/reference/api/pandas.StringDtype.html)

It also fixes a bug that occurs if you create a pandas dataframe with a numeric column name. i.e using
```
df = pd.DataFrame(["test", "data"])
>>> type(df.columns[0])
int
```