### PR TITLE
Hotfix ci by disabling odc wheel

### DIFF
--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -7,3 +7,5 @@ build:
     - ecmwf/eckit@develop
     - ecmwf/odc@develop
   parallel: 64
+  env:
+    - FINDLIBS_DISABLE_PACKAGE=yes


### PR DESCRIPTION
We currently dont have means for using odclib wheel for pyodc during the ci build -- thus the odclib comes from most recent released main, not from current develop as is expected in the ci pipeline

This hotfixes is by disabling the wheel import, thus relying, via findlibs, on the odc compiled from devel. Long term fix will build the wheel from the compiled odc and install it into pyodc's venv for the test