### PR TITLE
Pin eckit and odclib dependencies to known working combination

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,10 @@ classifiers =
         Intended Audience :: Developers
         License :: OSI Approved :: Apache Software License
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.8
-        Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
         Programming Language :: Python :: 3.11
         Programming Language :: Python :: 3.12
+        Programming Language :: Python :: 3.13
         Programming Language :: Python :: Implementation :: CPython
         Programming Language :: Python :: Implementation :: PyPy
         Operating System :: OS Independent
@@ -26,13 +25,13 @@ classifiers =
 package_dir =
     = src
 packages = pyodc, codc
-python_requires = >=3.8
+python_requires = >=3.10
 include_package_data = True
 test_suite = tests
 install_requires =
     cffi
     odclib==1.6.0
-    eckitlib==1.28.4
+    eckitlib==1.28.5
     findlibs>=0.1.0
     pandas
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ include_package_data = True
 test_suite = tests
 install_requires =
     cffi
-    odclib>=1.6.0,<1.7.0
+    odclib==1.6.0
+    eckitlib==1.28.4
     findlibs>=0.1.0
     pandas
     packaging

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 env_list =
-    py{38,39,310,311,312}
+    py{310,311,312,313}
 minversion = 4.16.0
 
 [testenv]


### PR DESCRIPTION
This pins the dependencies on odc and eckit to a known working combination. This will remain in place until odclib has its own dependencies sorted out. 